### PR TITLE
Update to support config.leader user entry that includes timeout_milliseconds key/value pair

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -178,7 +178,9 @@ function M.apply_to_config(config, _)
   end
 
   local keys = {
-    { key = config.leader.key, mods = "LEADER|" .. config.leader.mods, action = act.SendKey({ key = config.leader, mods = config.leader.mods }) },
+    { key = config.leader.key,
+      mods = "LEADER|" .. config.leader.mods,
+      action = act.SendKey({ key = config.leader.key, mods = config.leader.mods }) },
 
     -- Workspaces
     { key = "$",               mods = "LEADER",                        action = M.action.RenameWorkspace },

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -178,7 +178,7 @@ function M.apply_to_config(config, _)
   end
 
   local keys = {
-    { key = config.leader.key, mods = "LEADER|" .. config.leader.mods, action = act.SendKey(config.leader) },
+    { key = config.leader.key, mods = "LEADER|" .. config.leader.mods, action = act.SendKey({ key = config.leader, mods = config.leader.mods }) },
 
     -- Workspaces
     { key = "$",               mods = "LEADER",                        action = M.action.RenameWorkspace },


### PR DESCRIPTION
If user defines config.leader as follows:

`config.leader = { key = "a", mods = "CTRL", timeout_milliseconds = 2000 }
`
An error occurs:

> `timeout_milliseconds` is not a valid KeyNoAction field. Possible alternatives
> are `key`, `mods`
