### PR TITLE
Changed key binding for activating tab to support either zero or one based indexing

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -227,8 +227,9 @@ function M.apply_to_config(config, _)
     { key = "[",          mods = "LEADER",      action = act.ActivateCopyMode },
   }
 
-  for i = 1, 9 do
-    table.insert(keys, { key = tostring(i), mods = "LEADER", action = act.ActivateTab(i - 1) })
+  local index_offset = config.tab_and_split_indices_are_zero_based and 0 or 1
+  for i = index_offset, 9 do
+    table.insert(keys, { key = tostring(i), mods = "LEADER", action = act.ActivateTab(i - index_offset) })
   end
 
   local copy_mode = {


### PR DESCRIPTION
The change supports either `tab_and_split_indices_are_zero_based` configuration.

Add the following line before calling `apply_to_config`:

`config.tab_and_split_indices_are_zero_based = true
`

or 

`config.tab_and_split_indices_are_zero_based = false
`
